### PR TITLE
refactor to split clustering into 2 protocols

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+3.2:
+    - split cluster picking into two protocols
+    - add missing params chunk_size and fit_sample_size to cmd args
+    - add a test for cluster-based embedding
+    - cluster tomos embedding now runs in parallel on GPUs
 3.1:
     - update version
     - add input masks option

--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,10 @@ Command to activate the Napari viewer environment.
 
 Verifying
 ---------
-To check the installation, simply run the following Scipion test:
+To check the installation, simply run the following Scipion tests:
 
-``scipion test tomotwin.tests.test_protocols_tomotwin.TestTomoTwinRefPicking``
+* ``scipion tests tomotwin.tests.test_protocols_tomotwin.TestTomoTwinRefBased``
+* ``scipion tests tomotwin.tests.test_protocols_tomotwin.TestTomoTwinClusterBased``
 
 Supported versions
 ------------------
@@ -85,6 +86,8 @@ Protocols
 ----------
 
 * reference-based picking
+* clustering-based picking (step 1)
+* clustering-based picking (step 2)
 * create tomo masks
 
 References

--- a/tomotwin/__init__.py
+++ b/tomotwin/__init__.py
@@ -32,7 +32,7 @@ from pyworkflow import Config
 from .constants import *
 
 
-__version__ = '3.1'
+__version__ = '3.2'
 _references = ['Rice2022']
 _logo = "tomotwin_logo.png"
 

--- a/tomotwin/protocols.conf
+++ b/tomotwin/protocols.conf
@@ -8,6 +8,7 @@ Tomography = [
 	{"tag": "section", "text": "Particles", "children": [
 	    {"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
 			{"tag": "protocol", "value": "ProtTomoTwinRefPicking", "text": "default"},
+			{"tag": "protocol", "value": "ProtTomoTwinClusterCreateUmaps", "text": "default"},
 			{"tag": "protocol", "value": "ProtTomoTwinClusterPicking", "text": "default"}
 		]}
     ]}

--- a/tomotwin/protocols/__init__.py
+++ b/tomotwin/protocols/__init__.py
@@ -24,6 +24,7 @@
 # *
 # **************************************************************************
 
-from .protocol_picking_ref import ProtTomoTwinRefPicking
+from .protocol_picking_cluster_umap import ProtTomoTwinClusterCreateUmaps
 from .protocol_picking_cluster import ProtTomoTwinClusterPicking
+from .protocol_picking_ref import ProtTomoTwinRefPicking
 from .protocol_create_masks import ProtTomoTwinCreateMasks

--- a/tomotwin/protocols/protocol_picking_cluster_umap.py
+++ b/tomotwin/protocols/protocol_picking_cluster_umap.py
@@ -1,0 +1,87 @@
+# **************************************************************************
+# *
+# * Authors:     Grigory Sharov (gsharov@mrc-lmb.cam.ac.uk)
+# *
+# * MRC Laboratory of Molecular Biology (MRC-LMB)
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+
+from pyworkflow import BETA
+import pyworkflow.protocol.params as params
+from .protocol_base import ProtTomoTwinBase
+
+
+class ProtTomoTwinClusterCreateUmaps(ProtTomoTwinBase):
+    """ Clustering-based picking with TomoTwin (step 1).
+
+    The first step includes tomograms embedding and creating UMAPs.
+    """
+
+    _label = 'clustering-based picking (step 1)'
+    _devStatus = BETA
+
+    def __init__(self, **kwargs):
+        ProtTomoTwinBase.__init__(self, **kwargs)
+        self.stepsExecutionMode = params.STEPS_PARALLEL
+
+    # --------------------------- DEFINE param functions ----------------------
+    def _defineParams(self, form):
+        self._defineInputParams(form)
+        self._defineEmbedParams(form)
+
+        form.addParallelSection(threads=1)
+
+    # --------------------------- INSERT steps functions ----------------------
+    def _insertAllSteps(self):
+        self._createFilenameTemplates()
+        convertStepId = self._insertFunctionStep(self.convertInputStep)
+
+        tomoIds = self._getInputTomos().aggregate(["COUNT"], "_tsId", ["_tsId"])
+        tomoIds = set([d['_tsId'] for d in tomoIds])
+
+        for tomoId in tomoIds:
+            tomoStep = self._insertFunctionStep(self.embedTomoStep, tomoId,
+                                                prerequisites=convertStepId)
+            self._insertFunctionStep(self.createUmapsStep, tomoId,
+                                     prerequisites=tomoStep)
+
+    # --------------------------- STEPS functions -----------------------------
+    def createUmapsStep(self, tomoId):
+        """ Estimate UMAP manifold and Generate Embedding Mask. """
+        self.runProgram(self.getProgram("tomotwin_tools.py"),
+                        self._getUmapArgs(tomoId))
+
+    # --------------------------- INFO functions ------------------------------
+    def _summary(self):
+        if self.isFinished():
+            return ["UMAP embeddings created for input tomograms."]
+
+
+    # --------------------------- UTILS functions ------------------------------
+    def _getUmapArgs(self, tomoId):
+        return [
+            f"umap -i embed/tomos/{tomoId}_embeddings.temb",
+            f"-o {tomoId}/",
+            f"--fit_sample_size {self.fitSampleSize.get()}",
+            f"--chunk_size {self.chunkSize.get()}"
+        ]

--- a/tomotwin/protocols/protocol_picking_cluster_umap.py
+++ b/tomotwin/protocols/protocol_picking_cluster_umap.py
@@ -24,8 +24,6 @@
 # *
 # **************************************************************************
 
-import os
-
 from pyworkflow import BETA
 import pyworkflow.protocol.params as params
 from .protocol_base import ProtTomoTwinBase
@@ -75,7 +73,6 @@ class ProtTomoTwinClusterCreateUmaps(ProtTomoTwinBase):
     def _summary(self):
         if self.isFinished():
             return ["UMAP embeddings created for input tomograms."]
-
 
     # --------------------------- UTILS functions ------------------------------
     def _getUmapArgs(self, tomoId):


### PR DESCRIPTION
3.2:
    - split cluster picking into two protocols
    - add missing params chunk_size and fit_sample_size to cmd args
    - add a test for cluster-based embedding
    - cluster tomos embedding now runs in parallel on GPUs
   
Close #14